### PR TITLE
Apple Pay support for Checkout.com's Prestashop module for v1.7

### DIFF
--- a/checkoutcom.php
+++ b/checkoutcom.php
@@ -180,9 +180,10 @@ class CheckoutCom extends PaymentModule
 
         $methods = array(
             CheckoutcomPaymentOption::getCard($this, $params),
-            // CheckoutcomPaymentOption::getApple($this, $params),
+            CheckoutcomPaymentOption::getApple($this, $params),
             CheckoutcomPaymentOption::getGoogle($this, $params),
         );
+
 
         $alternatives = CheckoutcomPaymentOption::getAlternatives($this, $params);
         foreach ($alternatives as $method) {

--- a/config/apple.json
+++ b/config/apple.json
@@ -1,0 +1,61 @@
+[
+  [
+    {
+      "name":"CHECKOUTCOM_APPLE_TITLE",
+      "label":"Payment Option Title",
+      "description":"",
+      "type":"text",
+      "icon":"",
+      "default":"Pay by Apple Pay with Checkout.com",
+      "required":1
+    },
+    {
+      "name":"CHECKOUTCOM_APPLE_ENABLED",
+      "label":"Enable Apple Pay",
+      "description":"",
+      "type":"bswitch",
+      "default":0,
+      "required":1,
+      "options":[
+        {
+          "id":"id_option",
+          "value":1,
+          "label":"Enabled"
+        },
+        {
+          "id":"id_option",
+          "value":0,
+          "label":"Disabled"
+        }
+      ]
+    },
+    {
+      "name":"CHECKOUTCOM_APPLE_MERCHANT_ID",
+      "label":"Merchant ID",
+      "desc":"Provide your Apple Merchant ID.",
+      "type":"text",
+      "default":"",
+      "required":1,
+      "col":2
+    },
+    {
+      "name":"CHECKOUTCOM_APPLE_KEY",
+      "label":"Apple Pay Key",
+      "desc":"Provide Path to Apple Pay .key File",
+      "type":"text",
+      "default":"",
+      "required":1,
+      "col":2
+    }
+  ,
+    {
+      "name":"CHECKOUTCOM_APPLE_CERTIFICATE",
+      "label":"Apple Pay Certificate",
+      "desc":"Provide Path to Apple Pay .pem File",
+      "type":"text",
+      "default":"",
+      "required":1,
+      "col":2
+    }
+  ]
+]

--- a/controllers/front/applepay.php
+++ b/controllers/front/applepay.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Checkout.com
+ * Authorised and regulated as an electronic money institution
+ * by the UK Financial Conduct Authority (FCA) under number 900816.
+ *
+ * PrestaShop v1.7
+ *
+ * @category  prestashop-module
+ * @package   Checkout.com
+ * @author    Platforms Development Team <platforms@checkout.com>
+ * @copyright 2010-2020 Checkout.com
+ * @license   https://opensource.org/licenses/mit-license.html MIT License
+ * @link      https://docs.checkout.com/
+ */
+
+use Checkout\Models\Response;
+use CheckoutCom\PrestaShop\Helpers\Debug;
+use CheckoutCom\PrestaShop\Helpers\Utilities;
+use CheckoutCom\PrestaShop\Classes\CheckoutcomCustomerCard;
+use CheckoutCom\PrestaShop\Classes\CheckoutcomPaymentHandler;
+
+class CheckoutcomApplepayModuleFrontController extends ModuleFrontController
+{
+    public function validate($url){
+        $merchant_id = Configuration::get('CHECKOUTCOM_APPLE_MERCHANT_ID');
+        $certificate = Configuration::get('CHECKOUTCOM_APPLE_CERTIFICATE');
+        $key = Configuration::get('CHECKOUTCOM_APPLE_KEY');
+        $domain = Configuration::get('PS_SHOP_DOMAIN_SSL');
+        $name = Configuration::get('PS_SHOP_NAME');
+        $curl = curl_init();
+        $json = json_encode([
+            'merchantIdentifier'=> $merchant_id,
+            'initiativeContext'=> $domain,
+            'initiative'=> 'web',
+            'displayName'=> $name,
+        ]);
+        $curl_opt = array(
+            CURLOPT_URL => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => "POST",
+            CURLOPT_SSLKEY => $key,
+            CURLOPT_SSLCERT => $certificate,
+            CURLOPT_POSTFIELDS =>$json,
+            CURLOPT_POST=>1,
+            CURLOPT_HTTPHEADER => array(
+                "Content-Type: application/json",
+            ),
+        );
+        curl_setopt_array($curl, $curl_opt);
+        $response = curl_exec($curl);
+        return $response;
+    }
+    public function postProcess()
+    {
+        $url = Tools::getAllValues()['url'];
+        header("Content-Type: application/json");
+        if(filter_var($url, FILTER_VALIDATE_URL)){
+            echo $this->validate($url);
+        }else{
+            echo json_encode([
+                'error'=>406,
+                'message'=>'URL parameter must be set and a valid Apple Pay session URL'
+            ]);
+        }
+        die;
+    }
+}

--- a/src/Classes/CheckoutcomPaymentHandler.php
+++ b/src/Classes/CheckoutcomPaymentHandler.php
@@ -21,10 +21,10 @@ class CheckoutcomPaymentHandler
             'key' => 'id',
             'class' => 'CheckoutCom\\PrestaShop\\Models\\Payments\\Card',
         ),
-        // array(
-        //     'key' => 'apple',
-        //     'class' => ''
-        // ),
+         array(
+             'key' => 'apple',
+             'class' => 'CheckoutCom\\PrestaShop\\Models\\Payments\\Apple'
+         ),
         array(
             'key' => 'google',
             'class' => 'CheckoutCom\\PrestaShop\\Models\\Payments\\Google',

--- a/src/Classes/CheckoutcomPaymentOption.php
+++ b/src/Classes/CheckoutcomPaymentOption.php
@@ -130,4 +130,37 @@ class CheckoutcomPaymentOption extends PaymentOption
 
         return $option;
     }
+    /**
+     * Generate payment option.
+     *
+     * @param <type> $module The module
+     * @param <type> $params The parameters
+     *
+     * @return PaymentOption the card
+     */
+    public static function getApple(&$module, &$params)
+    {
+        if (!Config::get('CHECKOUTCOM_APPLE_ENABLED')) {
+            return;
+        }
+
+        // Load Context
+        $context = \Context::getContext();
+
+        $context->smarty->assign([
+            'module' => $module->name,
+            'CHECKOUTCOM_PUBLIC_KEY' => Config::get('CHECKOUTCOM_PUBLIC_KEY'),
+            'merchantid' => Config::get('CHECKOUTCOM_APPLE_ID'),
+            'live' => Config::get('CHECKOUTCOM_LIVE_MODE'),
+            'invoiceid' => $context->cart->id_address_invoice,
+        ]);
+
+        $option = new PaymentOption();
+        $option->setForm($context->smarty->fetch($module->getLocalPath() . 'views/templates/front/payments/apple.tpl'))
+            ->setModuleName($module->name . '-apple-form')
+            ->setLogo(\Media::getMediaPath(_PS_MODULE_DIR_ . $module->name . '/views/img/applepay.svg'))
+            ->setCallToActionText($module->l(Config::get('CHECKOUTCOM_APPLE_TITLE')));
+
+        return $option;
+    }
 }

--- a/src/Classes/CheckoutcomPaymentOption.php
+++ b/src/Classes/CheckoutcomPaymentOption.php
@@ -143,7 +143,10 @@ class CheckoutcomPaymentOption extends PaymentOption
         if (!Config::get('CHECKOUTCOM_APPLE_ENABLED')) {
             return;
         }
-
+        //get default shop country id
+        $id_country = Tools::getCountry();
+        //get country object
+        $country = new Country($id_country);
         // Load Context
         $context = \Context::getContext();
 
@@ -152,6 +155,7 @@ class CheckoutcomPaymentOption extends PaymentOption
             'CHECKOUTCOM_PUBLIC_KEY' => Config::get('CHECKOUTCOM_PUBLIC_KEY'),
             'merchantid' => Config::get('CHECKOUTCOM_APPLE_ID'),
             'live' => Config::get('CHECKOUTCOM_LIVE_MODE'),
+            'merchant_country_iso' => strtoupper($country->iso_code),
             'invoiceid' => $context->cart->id_address_invoice,
         ]);
 

--- a/src/Models/Payments/Apple.php
+++ b/src/Models/Payments/Apple.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CheckoutCom\PrestaShop\Models\Payments;
+
+use Checkout\Models\Tokens\ApplePay;
+use Checkout\Models\Tokens\ApplePayHeader;
+use Checkout\Models\Payments\TokenSource;
+use CheckoutCom\PrestaShop\Classes\CheckoutApiHandler;
+use Checkout\Library\Exceptions\CheckoutHttpException;
+
+class Apple extends Method
+{
+    /**
+     * Process payment.
+     *
+     * @param array $params The parameters
+     *
+     * @return Response ( description_of_the_return_value )
+     */
+    public static function pay(array $params)
+    {
+        $token = '';
+        $payment = null;
+        $data = json_decode($params['token'], true);
+        $header = new ApplePayHeader($data['header']['transactionId'], $data['header']['publicKeyHash'], $data['header']['ephemeralPublicKey']);
+        $applepay = new ApplePay($data['version'], $data['signature'], $data['data'], $header);
+        try {
+            $token = CheckoutApiHandler::api()->tokens()->request($applepay);
+        } catch (CheckoutHttpException $ex) {
+            \PrestaShopLogger::addLog($ex->getBody(), 3, $ex->getCode(), 'checkoutcom' , 0, true);
+        }
+
+        if ($token) {
+            $payment = static::makePayment(new TokenSource($token->getTokenId()));
+            $response = static::request($payment);
+        }
+        return $response;
+    }
+}

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -29,6 +29,7 @@
 	<li><a href="#template_2" role="tab" data-toggle="tab">{l s='Card Payments' mod='checkoutcom'}</a></li>
 	<li><a href="#template_3" role="tab" data-toggle="tab">{l s='Alternative Payments' mod='checkoutcom'}</a></li>
 	<li><a href="#template_4" role="tab" data-toggle="tab">{l s='Google Pay' mod='checkoutcom'}</a></li>
+	<li><a href="#template_5" role="tab" data-toggle="tab">{l s='Apple Pay' mod='checkoutcom'}</a></li>
 </ul>
 
 <!-- Tab panes -->
@@ -37,4 +38,5 @@
 	<div class="tab-pane" id="template_2">{$config_card}</div>
 	<div class="tab-pane" id="template_3">{$config_alternatives}</div>
 	<div class="tab-pane" id="template_4">{$config_google}</div>
+	<div class="tab-pane" id="template_5">{$config_apple}</div>
 </div>

--- a/views/templates/front/payments/apple.tpl
+++ b/views/templates/front/payments/apple.tpl
@@ -34,10 +34,7 @@
                     merchantCapabilities: [
                         "supports3DS"
                     ],
-                    supportedNetworks: [
-                        "visa",
-                        "masterCard"
-                    ],
+                    supportedNetworks: ['visa', 'masterCard', 'amex', 'discover'],
                     total: {
                         label: prestashop.shop.name,
                         amount: prestashop.cart.totals.total.amount

--- a/views/templates/front/payments/apple.tpl
+++ b/views/templates/front/payments/apple.tpl
@@ -65,6 +65,7 @@
 
                 apple_pay_.onvalidatemerchant = function onvalidatemerchant(event) {
                     var appleValidationUrl = event.validationURL;
+                    //@todo: use XMLHttpRequest instead of jQuery post
                     $.post(apple_validate_url,{ url: appleValidationUrl },
                         function( data ) {
                             apple_pay_.completeMerchantValidation(JSON.parse(data));

--- a/views/templates/front/payments/apple.tpl
+++ b/views/templates/front/payments/apple.tpl
@@ -70,7 +70,6 @@
                             apple_pay_.completeMerchantValidation(JSON.parse(data));
                         }, 'text')
                         .fail(function(xhr, textStatus, errorThrown) {
-                            console.log(errorThrown, textStatus);
                             apple_pay_.abort();
                         });
                 };

--- a/views/templates/front/payments/apple.tpl
+++ b/views/templates/front/payments/apple.tpl
@@ -1,0 +1,112 @@
+<form name="{$module}" id="{$module}-apple-form" action="{$link->getModuleLink($module, 'placeorder', [], true)|escape:'html'}" data-key="{$CHECKOUTCOM_PUBLIC_KEY}" data-merchantid="{$merchantid}" data-live="{$live}" data-invoiceid="{$invoiceid}" data-module="{$module}" method="POST">
+    <input id="{$module}-apple-source" type="hidden" name="source" value="apple" required>
+    <input type="hidden" id="{$module}-apple-token" name="token" value="" />
+</form>
+
+
+
+{literal}
+    <script type="text/javascript">
+        var applePayForm = document.querySelector('#checkoutcom-apple-form');
+        applePayForm.addEventListener("form:show", function(event) {
+            // Hide core confirmation
+            window.checkoutcom.$confirmation.childNodes[1].style.display = 'none';
+
+            var button = document.createElement('div');
+            button.id = 'apple-pay-div';
+            // Create Apple Pay button
+            button.innerHTML = '<a id="checkoutcom-apple-pay" lang="us" class="applePayButton" style="-webkit-appearance: -apple-pay-button; -apple-pay-button-type: plain; -apple-pay-button-style: black; height: 60px; width: 275px;" title="Start Apple Pay" role="link" tabindex="0"></a>';
+            // button.id = 'checkoutcom-apple-pay';
+
+            window.checkoutcom.$confirmation.appendChild(button);
+
+            var applePayButton = document.querySelector('.applePayButton');
+            var applePayOptionForm = document.querySelector('.payment-option-checkoutcom-apple-form');
+            if(window.ApplePaySession && ApplePaySession.canMakePaymentsWithActiveCard(applePayForm.dataset.merchantid)){
+                applePayOptionForm.style.display = "block";
+            }else{
+                applePayOptionForm.style.display = "none";
+            }
+            applePayButton.addEventListener('click', function(){
+                var paymentReq = {
+                    countryCode: "SA",
+                    currencyCode: prestashop.currency.iso_code,
+                    merchantCapabilities: [
+                        "supports3DS"
+                    ],
+                    supportedNetworks: [
+                        "visa",
+                        "masterCard"
+                    ],
+                    total: {
+                        label: "Qavashop",
+                        amount: prestashop.cart.totals.total.amount
+                    },
+                    lineItems: [
+                        {
+                            label: "VAT",
+                            amount: prestashop.cart.subtotals.tax.amount,
+                            type: "final"
+                        }
+                    ]
+                };
+
+                var apple_pay_ = new ApplePaySession(6, paymentReq);
+                apple_pay_.begin();
+                var apple_validate_url = "module/" + applePayForm.dataset.module + "/applevalidate";
+                apple_pay_.onpaymentauthorized = function onpaymentauthorized(event) {
+                    var token = event.payment.token;
+                    if(token){
+                        const $token = document.getElementById('checkoutcom-apple-token');
+                        $token.value = JSON.stringify(token.paymentData);
+                        CheckoutcomApplePay(document.getElementById('checkoutcom-apple-form'));
+                        apple_pay_.completePayment(ApplePaySession.STATUS_SUCCESS);
+                    }else{
+                        apple_pay_.completePayment(ApplePaySession.STATUS_FAILURE);
+                    }
+                };
+
+                apple_pay_.onvalidatemerchant = function onvalidatemerchant(event) {
+                    var appleValidationUrl = event.validationURL;
+                    $.post(apple_validate_url,{ url: appleValidationUrl },
+                        function( data ) {
+                            apple_pay_.completeMerchantValidation(JSON.parse(data));
+                        }, 'text')
+                        .fail(function(xhr, textStatus, errorThrown) {
+                            console.log(errorThrown, textStatus);
+                            apple_pay_.abort();
+                        });
+                };
+            });
+            document.getElementById('apple-pay-div').scrollIntoView();
+        });
+
+        // Apple Pay Form Exit
+        applePayForm.addEventListener("form:hide", function(event) {
+            // Show confirmation button
+            window.checkoutcom.$confirmation.childNodes[1].style.display = 'inline-block';
+            document.getElementById('checkoutcom-apple-pay').remove();
+        });
+        /**
+         * Checkout Apple Pay Class.
+         *
+         * @class      CheckoutcomApplePay (name)
+         * @param      {<type>}    $form   The form
+         * @return     {Function}  { description_of_the_return_value }
+         */
+        function CheckoutcomApplePay($form) {
+            const $token = document.getElementById('checkoutcom-apple-token');
+            const $source = document.getElementById('checkoutcom-apple-source');
+            var submitted = false;
+            $form.onsubmit = function(e) {
+                e.preventDefault();
+                if($token.value && !submitted) {
+                    submitted = true;
+                    $source.value = 'apple';
+                    $form.submit();
+                }
+            };
+            $form.submit();
+        }
+    </script>
+{/literal}

--- a/views/templates/front/payments/apple.tpl
+++ b/views/templates/front/payments/apple.tpl
@@ -1,4 +1,4 @@
-<form name="{$module}" id="{$module}-apple-form" action="{$link->getModuleLink($module, 'placeorder', [], true)|escape:'html'}" data-key="{$CHECKOUTCOM_PUBLIC_KEY}" data-merchantid="{$merchantid}" data-live="{$live}" data-invoiceid="{$invoiceid}" data-module="{$module}" method="POST">
+<form name="{$module}" id="{$module}-apple-form" action="{$link->getModuleLink($module, 'placeorder', [], true)|escape:'html'}" data-key="{$CHECKOUTCOM_PUBLIC_KEY}" data-merchant_country_iso="{$merchant_iso_code}" data-merchantid="{$merchantid}" data-live="{$live}" data-invoiceid="{$invoiceid}" data-module="{$module}" method="POST">
     <input id="{$module}-apple-source" type="hidden" name="source" value="apple" required>
     <input type="hidden" id="{$module}-apple-token" name="token" value="" />
 </form>
@@ -22,14 +22,14 @@
 
             var applePayButton = document.querySelector('.applePayButton');
             var applePayOptionForm = document.querySelector('.payment-option-checkoutcom-apple-form');
-            if(window.ApplePaySession && ApplePaySession.canMakePaymentsWithActiveCard(applePayForm.dataset.merchantid)){
+            if(window.ApplePaySession && ApplePaySession.canMakePayments()){
                 applePayOptionForm.style.display = "block";
             }else{
                 applePayOptionForm.style.display = "none";
             }
             applePayButton.addEventListener('click', function(){
                 var paymentReq = {
-                    countryCode: "SA",
+                    countryCode: applePayForm.dataset.merchant_country_iso,
                     currencyCode: prestashop.currency.iso_code,
                     merchantCapabilities: [
                         "supports3DS"
@@ -39,7 +39,7 @@
                         "masterCard"
                     ],
                     total: {
-                        label: "Qavashop",
+                        label: prestashop.shop.name,
                         amount: prestashop.cart.totals.total.amount
                     },
                     lineItems: [

--- a/views/templates/front/payments/apple.tpl
+++ b/views/templates/front/payments/apple.tpl
@@ -53,7 +53,7 @@
 
                 var apple_pay_ = new ApplePaySession(6, paymentReq);
                 apple_pay_.begin();
-                var apple_validate_url = "module/" + applePayForm.dataset.module + "/applevalidate";
+                var apple_validate_url = "module/" + applePayForm.dataset.module + "/applepay";
                 apple_pay_.onpaymentauthorized = function onpaymentauthorized(event) {
                     var token = event.payment.token;
                     if(token){


### PR DESCRIPTION
Added support for Apple pay using underlying Checkout SDK for PHP and Apple Pay JS support for safari.